### PR TITLE
install.sh: fix unable to download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,9 +37,9 @@ case $ARCH in
     ;;
 esac
 
-VERSION=$(curl https://api.github.com/repos/Mikubill/cowtransfer-uploader/releases/latest 2>&1 | grep -o "[0-9]\.[0-9]\.[0-9]" | head -n 1)
+DOWNLOAD_URL=$(curl -fsSL https://api.github.com/repos/Mikubill/cowtransfer-uploader/releases/latest | grep "browser_download_url.*$OS.*$ARCH" | cut -d '"' -f 4)
 
-curl -L https://github.com/Mikubill/cowtransfer-uploader/releases/download/v$VERSION/cowtransfer-uploader_$VERSION\_$OS\_$ARCH.tar.gz | tar xz
+curl -L "$DOWNLOAD_URL" | tar xz
 
 printf "\nCowTransfer-uploader Downloded.\n\n"
 exit 0


### PR DESCRIPTION
可能因为 release 文件名变动导致了下载链接格式不正确，引发了这个问题。
```
$ curl -sL https://git.io/cowtransfer | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0      9      0  0:00:01 --:--:--  0:00:01     9

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```
提供一个直接获取匹配系统和平台架构获取下载链接的方法，只要文件名中的系统和平台架构信息是正确的即可，文件名的其它变动都不会再导致这个问题发生了。